### PR TITLE
Make official test names more unique

### DIFF
--- a/official_test.go
+++ b/official_test.go
@@ -51,7 +51,7 @@ func TestOfficial(t *testing.T) {
 
 	for _, group := range officialTests.Groups {
 		for _, test := range group.Tests {
-			testName := fmt.Sprintf("%s/%s", group.Name, test.Name)
+			testName := fmt.Sprintf("%s/%s/%s/%s", group.Name, test.Name, test.InputFile, test.Expression.Expression)
 			totalTests++
 			fhir, err := readFhirTestFile(convertXmlFileNameToJsonFileName(test.InputFile))
 			assert.NoError(t, err)


### PR DESCRIPTION
There are different official tests that have the same name within the same group name.  So, while yes, they show up separately, I'm giving them a unique name based on the input file and the FHIR path.  An example `testObservations/testPolymorphismIsA`.  There are two `testPolymorphismIsA` tests.  They both use the same input file, but have different FHIR path.